### PR TITLE
add reference to Origin in What is OKD section

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -77,7 +77,7 @@ title: OKD - Enterprise Open Source Kubernetes Distribution
       <div class="info_vertical animated">
         <h1>
           OKD
-          <span>Users</span>
+          <span>End User Community</span>
         </h1>
       </div>
       <div class="container wow fadeInUp">
@@ -120,7 +120,7 @@ title: OKD - Enterprise Open Source Kubernetes Distribution
               </div>
               <div class="col-md-6 col-xs-12">
                 <p>
-                  OKD embeds Kubernetes and extends it with <strong>security</strong> and other integrated concepts. An OKD release corresponds
+                  OKD embeds Kubernetes and extends it with <strong>security</strong> and other integrated concepts. OKD is also referred to as Origin in github and in the documentation. An OKD release corresponds
                   to the Kubernetes distribution - for example, OKD 1.7 includes Kubernetes 1.7.
                 </p>
                 <p>


### PR DESCRIPTION
inserted "OKD is also referred to as Origin in github and in the documentation."
changed the H1 title from "OKD Users" to "OKD End User Community"