### PR TITLE
fixed rackspace logo syntax error

### DIFF
--- a/data/users.yml
+++ b/data/users.yml
@@ -31,4 +31,4 @@ users:
     logo: arris.png
   - name: Rackspace
     link: https://www.rackspace.com/
-    logo: rackspace.png"
+    logo: rackspace.png


### PR DESCRIPTION
removed " from the end of logo file name