### PR TITLE
minor edits

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -4,7 +4,7 @@ title: OKD - Enterprise Open Source Kubernetes Distribution
 
 <% content_for :header do %>
 <h1 class="animated fadeInDown delay" style="font-size: 48px;"></h1>
-<p class="animated fadeInUp delay">OKD is the upstream community kubernetes distribution that powers <a href="https://www.openshift.com" class="headerlink" target="_blank" style="font-weight: 400;">Red Hat OpenShift</a>. Built around a core of Docker container packaging and Kubernetes container cluster management, OKD is also augmented by application lifecycle management functionality and DevOps tooling. OKD provides a complete open source container application platform.</p>
+<p class="animated fadeInUp delay">OKD is the upstream community kubernetes distribution that powers <a href="https://www.openshift.com" class="headerlink" target="_blank" style="font-weight: 400;">Red Hat OpenShift</a>. Built around a core of docker container packaging and Kubernetes container cluster management, OKD is also augmented by application lifecycle management functionality and DevOps tooling. OKD provides a complete open source container application platform.</p>
 <% end %>
 
 <div class="info_title wow fadeInDown" id="try">
@@ -118,8 +118,8 @@ title: OKD - Enterprise Open Source Kubernetes Distribution
               </div>
               <div class="col-md-6 col-xs-12">
                 <p>
-                  OKD embeds Kubernetes and extends it with <strong>security</strong> and other integrated concepts. OKD is also referred to as Origin in github and in the documentation. An OKD release corresponds
-                  to the Kubernetes distribution - for example, OKD 1.7 includes Kubernetes 1.7. If you are looking for enterprise-level support, or information on partner certification, Red Hat also offers <a href="https://openshift.com" target="_blank">Red Hat OpenShift Container Platform.</a>
+                  OKD embeds Kubernetes and extends it with <strong>security</strong> and other integrated concepts. OKD is also referred to as Origin in github and in the documentation. An OKD release corresponds to the Kubernetes distribution - for example, OKD 1.10 includes Kubernetes 1.10.
+                  If you are looking for enterprise-level support, or information on partner certification, Red Hat also offers <a href="https://openshift.com" target="_blank">Red Hat OpenShift Container Platform.</a>
                 </p>
                 <p>
                   Check the <a href="https://github.com/openshift/origin/blob/master/README.md" target="_blank">README file</a> for more


### PR DESCRIPTION
in Opening Paragraph:
lowercase d on Docker in opening paragraph 
in What's OKD Section:
changed "An OKD release corresponds to the Kubernetes distribution - for example, OKD 1.7 includes Kubernetes 1.7. " to "An OKD release corresponds to the Kubernetes distribution - for example, OKD 1.10 includes Kubernetes 1.10."