### PR TITLE
adding Origin back into the subtitle tagline

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,10 +1,10 @@
 ---
-title: OKD - The Upstream Community Distribution of Kubernetes that powers Red Hat OpenShift
+title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat OpenShift.
 ---
 
 <% content_for :header do %>
 <h1 class="animated fadeInDown delay">
-  The Upstream Community Distribution of Kubernetes that powers <a href="https://www.openshift.com" class="headerlink" target="_blank" style="font-weight: 400;">Red Hat OpenShift</a>. 
+  The Origin Community Distribution of Kubernetes that powers <a href="https://www.openshift.com" class="headerlink" target="_blank" style="font-weight: 400;">Red Hat OpenShift</a>. 
 </h1>
 <h1 class="animated fadeInDown delay" style="font-size: 36px;"></h1>
 <p class="animated fadeInUp delay">Built around a core of docker container packaging and Kubernetes container cluster management, OKD is also augmented by application lifecycle management functionality and DevOps tooling. OKD provides a complete open source container application platform.</p>


### PR DESCRIPTION
The Origin Community Distribution of Kubernetes