### PR TITLE
source: Pin cluster_up_down to v4.0.0-alpha.0

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -42,7 +42,7 @@ description: Download the OKD server binaries and command line client tools.
                   <a href="https://docs.okd.io/latest/cli_reference/get_started_cli.html" target="_blank">CLI&nbsp;Reference</a>
                 </div>
                 <div class="col-xs-6">
-                  <a href="https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md" target="_blank"><code>oc&nbsp;cluster</code>&nbsp;Reference</a>
+                  <a href="https://github.com/openshift/origin/blob/v4.0.0-alpha.0/docs/cluster_up_down.md" target="_blank"><code>oc&nbsp;cluster</code>&nbsp;Reference</a>
                 </div>
               </div>
             </div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -31,7 +31,7 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
           </div>
           <div class="row text-center">
             <div class="col-sm-offset-2 col-sm-4">
-              <a id="get-started" class="code-button" href="https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md" target="_blank">Get&nbsp;Started</a>
+              <a id="get-started" class="code-button" href="https://github.com/openshift/origin/blob/v4.0.0-alpha.0/docs/cluster_up_down.md" target="_blank">Get&nbsp;Started</a>
             </div>
             <div class="col-sm-4">
               <%= link_to "Download&nbsp;oc", "/download.html#oc-platforms", class: "code-button" %>


### PR DESCRIPTION
Previously we were floating with master, but the file is gone since openshift/origin@f1206f2e (openshift/origin#21484) and now the master link 404s.  The last master-branch commit before the removal was openshift/origin@e8b52089 (openshift/origin#21387), so we could have pinned there, but I've rolled back to v4.0.0-alpha.0 to sit on a tag.  Differences between the tagged version and the last version:

```console
$ git describe --always e8b52089
v4.0.0-alpha.0-574-ge8b5208
$ git diff -U1 v4.0.0-alpha.0..e8b52089 -- docs/cluster_up_down.md
diff --git a/docs/cluster_up_down.md b/docs/cluster_up_down.md
index 61e1a95..a5950a0 100644
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -222,3 +222,3 @@ docker cp origin:/var/lib/origin/openshift.local.config .

-To persist data across restarts, specify a valid host directory in the `--host-data-dir` argument when starting your cluster
+To persist data across restarts, specify a valid host directory in the `--base-dir` argument when starting your cluster
 with `oc cluster up`. As long as the same value is specified every time, the data will be preserved across restarts.
```

I don't know how significant that difference is, but I expect more users are likely to be using a released version of `oc` than one built from one of the 574 later commits, so I went with the tag.  On the other hand, I don't know how many folk will have built from v4.0.0-alpha.0; maybe I should have rolled back to v3.11.0?  Anyhow, with this change it will no longer 404.