### PR TITLE
removed references to Docker

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -7,7 +7,7 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
   The Origin Community Distribution of Kubernetes that powers <a href="https://www.openshift.com" class="headerlink" target="_blank" style="font-weight: 400;">Red Hat OpenShift</a>.
 </h1>
 <h1 class="animated fadeInDown delay" style="font-size: 36px;"></h1>
-<p class="animated fadeInUp delay">Built around a core of docker container packaging and Kubernetes container cluster management, OKD is also augmented by application lifecycle management functionality and DevOps tooling. OKD provides a complete open source container application platform.</p>
+<p class="animated fadeInUp delay">Built around a core of OCI container packaging and Kubernetes container cluster management, OKD is also augmented by application lifecycle management functionality and DevOps tooling. OKD provides a complete open source container application platform.</p>
 <% end %>
 <div class="info_title wow fadeInDown" id="try">
   <i class="fa fa-download left"></i>
@@ -54,13 +54,13 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
             <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
               <h2>Run OKD in a Container</h2>
               <p>
-                Want to get started quickly and easily? Just <a href="https://docs.okd.io/latest/getting_started/administrators.html#running-in-a-docker-container">run OKD in a Docker container</a> by itself.
+                Want to get started quickly and easily? Just <a href="https://docs.okd.io/latest/getting_started/administrators.html#running-in-a-docker-container">run OKD in a  container</a> by itself.
               </p>
             </div>
                     <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
               <h2>Run the All-In-One VM with&nbsp;Minishift</h2>
               <p>
-                Try out a fully functioning OKD instance with an integrated Docker registry, running locally on your machine with <%= link_to "Minishift", "/minishift/index.html" %>.
+                Try out a fully functioning OKD instance with an integrated container registry, running locally on your machine with <%= link_to "Minishift", "/minishift/index.html" %>.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Change:
Built around a core of docker container packaging and Kubernetes container 
to

Built around a core of OCI container packaging and Kubernetes container 

Change:
Want to get started quickly and easily? Just run OKD in a Docker container by itself.

to:
Want to get started quickly and easily? Just run OKD in a container by itself.