### PR TITLE
source/index: Standardize "Cri-O" and "Crio-O" -> "CRI-O"

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -202,7 +202,7 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
           <div class="col-sm-4">
             <div class="technology-section">
               <div class="head-tech">
-                <%= image_tag 'logo-crio-h.svg', {:alt => 'Crio-O logo', :class => 'logo_tech'} %>
+                <%= image_tag 'logo-crio-h.svg', {:alt => 'CRI-O logo', :class => 'logo_tech'} %>
               </div>
               <div class="caption-tech">
                 <p>A lightweight container runtime for Kubernetes.</p>
@@ -300,7 +300,7 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
                   <a href="https://github.com/operator-framework">Operator Framework</a>
                 </li>
                 <li>
-                  <a href="http://cri-o.io/">Cri-O</a>
+                  <a href="http://cri-o.io/">CRI-O</a>
                 </li>
                  <li>
                   <a href="https://github.com/prometheus/prometheus">Prometheus</a>


### PR DESCRIPTION
CRI-O is [the preferred casing][1] for the acronym (Container Runtime Interface - Open Container Initiative).

[1]: http://cri-o.io/