### PR TITLE
source/index: Update Bugzilla product "OpenShift Origin" -> "OKD"

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -311,7 +311,7 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
           <h2>File a Bug</h2>
           <p>
             Found a bug? Let us know! OKD uses a
-            <a href="https://bugzilla.redhat.com/describecomponents.cgi?product=OpenShift%20Origin">public Bugzilla instance</a>.
+            <a href="https://bugzilla.redhat.com/describecomponents.cgi?product=OKD">public Bugzilla instance</a>.
           </p>
           <h2>Talk to Us</h2>
           <ul>


### PR DESCRIPTION
I don't know when the Bugzilla product was changed to match the rebranding, but there is no longer an "OpenShift Origin" product there.