### PR TITLE
swap kubevirt for docker

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -291,7 +291,7 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
                   <a href="https://github.com/kubernetes/kubernetes">Kubernetes</a>
                 </li>
                 <li>
-                  <a href="https://github.com/docker/docker">Docker</a>
+                  <a href="http://kubevirt.io/">Kubevirt</a>
                 </li>
                 <li>
                   <a href="https://coreos.com/os/docs/latest/">CoreOS</a>


### PR DESCRIPTION
listing kubevirt instead of Docker in this "Check out the other repositories we're working on:" list