### PR TITLE
fix: 'Ready to Join' button in index now points to the correct url

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -356,7 +356,7 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
               </div>
               <div class="row">
                 <div class="col-md-4 col-md-offset-4 col-xs-10 col-xs-offset-1 text-center more-btn" id="blog-btn">
-                  <a class="btn btn-primary" href="#join">Ready to Join?</a>
+                  <a class="btn btn-primary" href="https://commons.openshift.org/index.html#join">Ready to Join?</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
h2. Problem
The "Ready to Join" button at the bottom of the page <https://www.okd.io/index.html> goes to an anchor "#join". But that anchor doesn't exist in the page.

h2. Fix
Changed the target URL of that button to <https://commons.openshift.org/index.html#join> which is used in the "Join Commons" link in the same page: https://github.com/openshift-cs/okd.io/blob/2838f4a60e4e6fed4bf25fc6999eb721df0c365f/source/index.html.erb#L261