### PR TITLE
line 125 update

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -125,7 +125,7 @@ title: OKD - The Origin Community Distribution of Kubernetes that powers Red Hat
               </div>
               <div class="col-md-6 col-xs-12">
                 <p>
-                  OKD embeds Kubernetes and extends it with <strong>security</strong> and other integrated concepts. OKD is also referred to as Origin in github and in the documentation. An OKD release corresponds to the Kubernetes distribution - for example, OKD 1.10 includes Kubernetes 1.10.
+                  OKD embeds Kubernetes and extends it with <strong>security</strong> and other integrated concepts. OKD is also referred to as Origin in github and in the documentation. The current alpha OKD 4 release corresponds to the Kubernetes distribution 1.16; the beta release will correspond to Kubernetes distribution 1.17
                   If you are looking for enterprise-level support, or information on partner certification, Red Hat also offers <a href="https://www.openshift.com" target="_blank">Red Hat OpenShift Container Platform.</a>
                 </p>
                 <p>


### PR DESCRIPTION
Replaced "OKD is also referred to as Origin in github and in the documentation. An OKD release corresponds to the Kubernetes distribution - for example, OKD 1.10 includes Kubernetes 1.10." with 
"The current alpha OKD 4 release corresponds to the Kubernetes distribution 1.16; the Beta release will correspond to Kubernetes distribution 1.17"