### PR TITLE
https://github.com/openshift/okd/releases

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -27,7 +27,7 @@ description: Download the OKD server binaries and command line client tools.
         <div class="row animated fadeInDown padding_bottom" id="server-platforms">
           <h2>Try OKD4 GA</h2>
           <div class="row instructions"><small>
-            <a href="https://github.com/openshift/okd/blob/master/README.md#getting-started" target="_blank">Installation Instructions</a>
+            <a href="https://github.com/openshift/okd/releases" target="_blank">Latest Release</a>
           </small></div>
         </div>
         <div class="row animated fadeInDown padding_bottom" id="server-platforms">


### PR DESCRIPTION
https://github.com/openshift/okd/releases replaces "https://github.com/openshift/okd/blob/master/README.md#getting-started" on line 30