### PR TITLE
source/download.html: remove links to 3.11 oc, fix OKD releases link

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -39,27 +39,9 @@ description: Download the OKD server binaries and command line client tools.
             <div class="col-md-offset-4 col-md-4 linux-platform"><h4><i class="fa fa-linux left"></i> Linux</h4></div>
           </div>
         </div>
-        <div class="row animated fadeInDown padding_bottom" id="oc-platforms">
-          <h2>Download oc Client Tools</h2>
-          <div class="row instructions"><small>
-            <div class="col-sm-5 col-centered">
-              <div class="row">
-                <div class="col-xs-6">
-                  <a href="https://docs.okd.io/latest/cli_reference/get_started_cli.html" target="_blank">CLI&nbsp;Reference</a>
-                </div>
-                <div class="col-xs-6">
-                  <a href="https://github.com/openshift/origin/blob/v4.0.0-alpha.0/docs/cluster_up_down.md" target="_blank"><code>oc&nbsp;cluster</code>&nbsp;Reference</a>
-                </div>
-              </div>
-            </div>
-          </small></div>
-          <div class="col-md-4 mac-platform"><h4><i class="fa fa-apple left"></i> Mac OS X</h4></div>
-          <div class="col-md-4 linux-platform"><h4><i class="fa fa-linux left"></i> Linux</h4></div>
-          <div class="col-md-4 windows-platform"><h4><i class="fa fa-windows left"></i> Windows</h4></div>
-        </div>
         <div class="row" id="more-details">
           <div class="info-verticle">
-            To see more details, including source code, check out our <%= link_to "<i class='fa fa-github'></i> Releases page", "https://github.com/openshift/origin/releases/latest" %>!
+            To see more details, including source code, check out our <%= link_to "<i class='fa fa-github'></i> Releases page", "https://github.com/openshift/okd/releases/latest" %>!
           </div>
         </div>
       </div>


### PR DESCRIPTION
OKD 4 is GA, so links to okd 3.11 should be replaced with OKD4 releases link