### PR TITLE
Remove reference to OKD 3.11 Release Notes

### DIFF
--- a/source/crc.html.erb
+++ b/source/crc.html.erb
@@ -50,11 +50,3 @@ description: Download CRC for OKD.
   </div>
 </section>
 
-<section class="opacy_bg_01 paddings" id="release-notes">
-  <div class="container">
-    <div class="row animated fadeInUp">
-      <div class="col-md-10 col-centered release-content">
-      </div>
-    </div>
-  </div>
-</section>


### PR DESCRIPTION
There was content from an old OKD 3.11 release being pulled into the new CRC download page.