### PR TITLE
remove release-content from crc page

### DIFF
--- a/source/crc.html.erb
+++ b/source/crc.html.erb
@@ -49,12 +49,3 @@ description: Download CRC for OKD.
     </div>
   </div>
 </section>
-
-<section class="opacy_bg_01 paddings" id="release-notes">
-  <div class="container">
-    <div class="row animated fadeInUp">
-      <div class="col-md-10 col-centered release-content">
-      </div>
-    </div>
-  </div>
-</section>


### PR DESCRIPTION
release-content


<section class="opacy_bg_01 paddings" id="release-notes">
  <div class="container">
    <div class="row animated fadeInUp">
      <div class="col-md-10 col-centered release-content">
      </div>
    </div>
  </div>
</section>