### PR TITLE
Added reference to fake pull secret for CRC

### DIFF
--- a/source/crc.html.erb
+++ b/source/crc.html.erb
@@ -37,6 +37,9 @@ description: Download CRC for OKD.
             <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/windows-amd64/" target="_blank">CRC for OKD4 - Windows image</a>
           </large></div>
           <div class="row instructions"><large>
+            <b>When prompted for a pull secret, use: {"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}</b>
+          </large></div>
+          <div class="row instructions"><large>
             <a href="https://code-ready.github.io/crc/" target="_blank">Getting Started Guide</a>
           </large></div>
         </div>


### PR DESCRIPTION
Users of the OKD release of CRC will be prompted for a pull secret when they execute `crc start`.

I added a reference to a fake pull secret that will work.