### PR TITLE
Fix references to CodeReady Containers

### DIFF
--- a/source/crc.html.erb
+++ b/source/crc.html.erb
@@ -1,13 +1,13 @@
 ---
-title: Download CRC for OKD
-description: Download CRC for OKD.
+title: Download CodeReady Containers for OKD
+description: Download CodeReady Containers for OKD.
 ---
 
 <% content_for :header do %>
 <h1 class="animated fadeInDown delay">
-  Download CRC for OKD - The Community Distribution of Kubernetes that powers Red Hat OpenShift
+  Download CodeReady Containers for OKD - The Community Distribution of Kubernetes that powers Red Hat OpenShift
 </h1>
-<p class="animated fadeInUp delay">Download the latest CRC for OKD</p>
+<p class="animated fadeInUp delay">Download the latest CodeReady Containers for OKD</p>
 <% end %>
 
 <% content_for :navbar do %>
@@ -25,16 +25,16 @@ description: Download CRC for OKD.
     <div class="row">
       <div class="col-md-10 col-centered">
         <div class="row animated fadeInDown padding_bottom" id="server-platforms">
-          <h2>Run a developer instance of OKD4 on your local workstation with CRC built for OKD</h2>
+          <h2>Run a developer instance of OKD4 on your local workstation with CodeReady Containers built for OKD</h2>
           <p></p>
           <div class="row instructions"><large>
-            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/macos-amd64/" target="_blank">CRC for OKD4 - Mac OS image</a>
+            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/macos-amd64/" target="_blank">CodeReady Containers for OKD4 - Mac OS image</a>
           </large></div>
           <div class="row instructions"><large>
-            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/linux-amd64/" target="_blank">CRC for OKD4 - Linux image</a>
+            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/linux-amd64/" target="_blank">CodeReady Containers for OKD4 - Linux image</a>
           </large></div>
           <div class="row instructions"><large>
-            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/windows-amd64/" target="_blank">CRC for OKD4 - Windows image</a>
+            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/windows-amd64/" target="_blank">CodeReady Containers for OKD4 - Windows image</a>
           </large></div>
           <div class="row instructions"><large>
             <b>When prompted for a pull secret, use: {"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}</b>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -56,9 +56,9 @@ title: OKD - The Community Distribution of Kubernetes that powers Red Hat OpenSh
               </p>
             </div>
                     <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-              <h2>Code Ready Containers for OKD: local OKD 4 cluster for development</h2>
+              <h2>CodeReady Containers for OKD: local OKD 4 cluster for development</h2>
               <p>
-                Code Ready Containers (CRC) brings a minimal OpenShift 4 cluster to your local laptop or desktop computer!  Download it here: <a href="/crc.html">CRC for OKD Images</a>
+                CodeReady Containers brings a minimal OpenShift 4 cluster to your local laptop or desktop computer!  Download it here: <a href="/crc.html">CodeReady Containers for OKD Images</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Previously, "Code Ready" was used. Also, as part of branding for CodeReady, we do not use abbreviations (such as "CRC") unless necessary to disambiguate the contents.