### PR TITLE
add a guides link to nav bar

### DIFF
--- a/source/layouts/_navbar.erb
+++ b/source/layouts/_navbar.erb
@@ -22,6 +22,9 @@
             <%= link_to "RECIPES", "/recipes.html" %>
           </li>
           <li>
+            <a href="https://github.com/elmiko/okd-deployment-configuration-guides">GUIDES</a>
+          </li>
+          <li>
             <!-- Place this tag where you want the button to render. -->
             <a href="https://github.com/openshift/okd"><img border="0" alt="GitHub" src="/img/Octocat.png" width="40vh" height="40vw" style="position:relative;top:-6px;"></a>
           </li>


### PR DESCRIPTION
this change adds a link to the okd deployment and configuration guides
repository. this is a temporary change as the guides are being migrated
into the site doc structure.