### PR TITLE
index.html: use new URL for OKD release controller

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -36,11 +36,11 @@ title: OKD - The Community Distribution of Kubernetes that powers Red Hat OpenSh
               <a id="get-started" class="code-button" href="https://github.com/openshift/okd#getting-started" target="_blank"><nobr>Get&nbsp;started</nobr></a>
             </div>
             <div class="col-sm-4">
-              <a id="changelogs" class="code-button" href="https://origin-release.svc.ci.openshift.org/" target="_blank"><nobr>Releases</nobr></a>
+              <a id="changelogs" class="code-button" href="https://amd64.origin.releases.ci.openshift.org/graph" target="_blank"><nobr>Releases</nobr></a>
             </div>
             <div class="col-sm-4">
               <a id="slack" class="code-button" href="https://kubernetes.slack.com/messages/openshift-dev" target="_blank"><nobr>Join us on Slack</nobr></a>
-            </div>            
+            </div>
           </div>
         </div>
       </div>
@@ -125,7 +125,7 @@ title: OKD - The Community Distribution of Kubernetes that powers Red Hat OpenSh
             </div>
 
 
-            <div id="carousel-example-generic" class="carousel slide" data-ride="carousel" data-interval="4000">        
+            <div id="carousel-example-generic" class="carousel slide" data-ride="carousel" data-interval="4000">
               <!-- Wrapper for slides -->
               <div class="carousel-inner" role="listbox">
                 <div class="item active">
@@ -175,11 +175,11 @@ title: OKD - The Community Distribution of Kubernetes that powers Red Hat OpenSh
                   <div class="carousel-caption">
                     ...
                   </div>
-                </div>                                                                                                
+                </div>
 
                 ...
               </div>
-            
+
               <!-- Controls -->
               <a class="left carousel-control" href="#carousel-example-generic" role="button" data-slide="prev">
                 <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
@@ -204,7 +204,7 @@ title: OKD - The Community Distribution of Kubernetes that powers Red Hat OpenSh
   <div class="info_title">
     <div class="info_vertical container">
       <div class="panda" style="background: url(img/okd-panda-flat_nerd_with_number.svg) no-repeat center center;">
-      </div>      
+      </div>
       <div class="row">
         <h1>
           <span>OKD Community</span>
@@ -220,7 +220,7 @@ title: OKD - The Community Distribution of Kubernetes that powers Red Hat OpenSh
               Please open issues for any bugs or problems you encounter, ask questions in the <b>#openshift-dev</b> on Kubernetes Slack Channel,
               or get involved in the OKD-WG by joining the OKD-WG google group.
               <br>
-              <ul>              
+              <ul>
                 <li>
                   Get started with the
                   <a href="https://github.com/openshift/okd/blob/master/CONTRIBUTING.md">Contributors Guide</a>


### PR DESCRIPTION
origin-release.svc.ci was deprecated in favor of https://amd64.origin.releases.ci.openshift.org/graph