### PR TITLE
Add installation page and deployment configuration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ tags: upgrade (choose tags to categorize articles)
 < MARKDOWN :-) >
 ```
 
+## Create a Guide
+
+Create a Markdown file in the directory **source/guides**.
+
+The filename must be in the format: **yyyy-mm-dd-\<title\>.html.markdown**.
+It is recommended that you reference the platform and deployment method in
+your title, for example `2021-12-31-vSphere-UPI-Disconnected-Network.html.markdown`.
+
+The first lines of the file must contain this [frontmatter](https://middlemanapp.com/basics/frontmatter/) data:
+```
+---
+title: <TITLE>
+authors:
+  - "@<Github handle>"
+last-updated: "yyyy-mm-dd"
+okd-version: "X.Y.Z"
+---
+
+< MARKDOWN :-) >
+```
+
 ## Deployment
 
 To deploy your changes please submit a pull request while following [our contribution guidelines](./CONTRIBUTING.md)

--- a/config.rb
+++ b/config.rb
@@ -40,6 +40,7 @@ ignore 'accelerators/*'
 
 activate :blog do |blog|
     # set options on blog
+    blog.name = "blog"
     blog.tag_template = "tag.html"
     blog.calendar_template = "calendar.html" 
     blog.layout = "article_layout"
@@ -49,6 +50,12 @@ activate :blog do |blog|
     blog.page_link = "p{num}"
     blog.per_page = 10    
 end
+
+activate :blog do |blog|
+  blog.name = "guides"
+  blog.prefix = "guides"
+  blog.layout = "article_layout"
+end  
 
 activate :syntax #, :line_numbers => true
 

--- a/source/blog.html.erb
+++ b/source/blog.html.erb
@@ -2,6 +2,7 @@
 title: Blog
 pageable: true
 per_page: 10
+blog: blog
 ---
 
 <% content_for :header do %>

--- a/source/guides/2021-03-24-AWS-IPI-default-deployment.html.markdown
+++ b/source/guides/2021-03-24-AWS-IPI-default-deployment.html.markdown
@@ -1,0 +1,39 @@
+---
+title: AWS IPI Default Deployment
+authors:
+  - "@elmiko"
+last-updated: "2021-03-24"
+okd-version: "4.7"
+---
+
+This describes the resources used by OpenShift after perfoming an installation
+using the default options for the installer.
+
+## Infrastructure
+
+### Compute
+
+* 3 control plane nodes
+  * instance type `m4.xlarge`, or `m5.xlarge` if previous not available in the region
+* 3 compute nodes
+  * instance type `m4.large`, or `m5.large` if previous not available in the region
+
+### Networking
+
+* 1 virtual private cloud
+* 1 public subnet per availability zone in the region
+* 1 private subnet per availability zone in the region
+* 1 NAT gateway per availability zone
+* 1 elastic IP address per NAT gateway
+* 3 elastic load balancers
+  * 1 external network load balancer for the master API server
+  * 1 internal network load balancer for the master API server
+  * 1 classic load balancer for the router
+* 21 elastic network interfaces, plus 1 interface per availability zone
+* 1 virtual private cloud gateway
+* 10 distinct security groups
+
+## Deployment
+
+See the [OKD documentation](https://docs.okd.io/latest/installing/installing_aws/preparing-to-install-on-aws.html)
+to proceed with deployment.

--- a/source/guides/2021-03-24-Azure-IPI-default-deployment.html.markdown
+++ b/source/guides/2021-03-24-Azure-IPI-default-deployment.html.markdown
@@ -1,0 +1,43 @@
+---
+title: Azure IPI Default Deployment
+authors:
+  - "@elmiko"
+last-updated: "2021-03-24"
+okd-version: "4.7"
+---
+
+This describes the resources used by OKD after perfoming an installation
+using the default options for the installer.
+
+## Infrastructure
+
+### Compute
+
+* 3 control plane nodes
+  * instance type `Standard_D8s_v3`
+* 3 compute nodes
+  * instance type `Standard_D4s_v3`
+
+### Networking
+
+* 1 virtual network (VNet) containing 2 subnets
+* 6 network interfaces
+* 3 network load balancers
+  * 1 public for compute node access
+  * 1 private for control plane access
+  * 1 public for control plane access
+* 2 public IP addresses
+  * 1 for the public compute load balancer
+  * 1 for the public control plane load balancer
+* 7 private IP addresses
+  * 1 per control plane node
+  * 1 per compute node
+  * 1 for the private control plane load balancer
+* 2 network security groups
+  * 1 for control plane allowing traffic on port 6443 from anywhere
+  * 1 for compute allowing traffic on ports 80 and 443 from the internet
+
+## Deployment
+
+See the [OKD documentation](https://docs.okd.io/latest/installing/installing_azure/installing-azure-account.html)
+to proceed with deployment.

--- a/source/guides/2021-03-24-GCP-IPI-default-deployment.html.markdown
+++ b/source/guides/2021-03-24-GCP-IPI-default-deployment.html.markdown
@@ -1,0 +1,42 @@
+---
+title: GCP IPI Default Deployment
+authors:
+  - "@elmiko"
+last-updated: "2021-03-24"
+okd-version: "4.7"
+---
+
+This describes the resources used by OKD after perfoming an installation
+using the default options for the installer.
+
+## Infrastructure
+
+### Compute
+
+* 3 control plane nodes
+  * instance type `n1-standard-4`
+* 3 compute nodes
+  * instance type `n1-standard-2`
+* 1 image
+
+### Networking
+
+* 2 networks
+* 2 subnetworks
+* 3 static IP addresses
+* 1 router
+* 2 routes
+* 3 target pools
+* 10 firewall rules
+* 2 forwarding rules
+* 3 in-use global IP addresses
+* 3 health checks
+
+### Platform
+
+* 5 IAM service accounts
+
+## Deployment
+
+See the [OKD documentation](https://docs.okd.io/latest/installing/installing_gcp/installing-gcp-account.html)
+to proceed with deployment.

--- a/source/guides/2021-03-24-Homelab-UPI-SriRamanujam.html.markdown
+++ b/source/guides/2021-03-24-Homelab-UPI-SriRamanujam.html.markdown
@@ -1,0 +1,96 @@
+---
+title: Sri's Overkill Homelab Setup
+---
+
+This document lays out the resources used to create my completely-overkill homelab. This cluster provides all the compute and storage I think I'll need for the foreseeable future, and the CPU, RAM, and storage can all be scaled vertically independently of each other. Not that I think I'll need to do that for a while.
+
+More detail into the deployment and my homelab's Terraform configuration can be found [here](https://github.com/SriRamanujam/okd-deployment).
+
+## Hardware
+
+* 3 hyper-converged hypervisors
+    * Ryzen 5 3600
+    * 64 GiB RAM
+    * 3x 4TiB HDD
+    * 2x 500GiB SSD in RAID1
+    * 1x 256GiB NVME for boot disk
+
+* 1 NUC I had laying around gathering dust
+    * Intel Core i3-5010U
+    * 16 GiB RAM
+    * 500GiB SSD
+
+## Main cluster
+
+My hypervisors each host an identical workload. The total size of this cluster is 3 control plane nodes, and 9 worker nodes.
+So it splits very nicely three ways. Each hypervisor hosts 1 control plane VM and 3 worker VMs.
+
+* 3 control plane nodes
+    * 4x CPU
+    * 10 GiB RAM
+    * 50 GiB disk
+
+* 9 worker nodes
+    * 8x CPU
+    * 16 GiB RAM
+    * 50 GiB root disk
+    * 4 TiB HDD for workload use
+
+* 1 bootstrap node (temporary, taken down after inital setup is complete)
+    * 4 vCPU
+    * 8 GiB RAM
+    * 120 GiB root disk
+
+## Supporting infrastructure
+
+### Networking
+
+OKD, and especially baremetal UPI OKD, requires a very specific network setup. You will most likely need something more
+flexible than your ISP's router to get everything fully configured. [The documentation](https://docs.okd.io/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-network-user-infra_installing-bare-metal) is very clear on the various DNS records and DHCP static allocations you will need to make, so I won't go into them here.
+
+However, there are a couple extra things that you may want to set for best results. In particular, I make sure that I have [PTR records](https://www.cloudflare.com/learning/dns/dns-records/dns-ptr-record/) set up for all my cluster nodes. This is extremely important as the nodes need a correct PTR record set up for them to auto-discover their hostname. Clusters typically do not set themselves up properly if there are hostname collisions!
+
+
+### API load balancer
+
+I run a separate smaller VM on the NUC as a single-purpose load balancer appliance, running HAProxy.
+
+* 1 load balancer VM
+    * 2x vCPU
+    * 256MiB RAM
+    * 10GiB disk
+
+The HAProxy config is straightforward. I adapted mine from the example config file created by the [ocp4-helpernode](https://github.com/RedHatOfficial/ocp4-helpernode/blob/master/templates/haproxy.cfg.j2) playbook.
+
+## Deployment
+
+I create the VMs on the hypervisors using Terraform. The [Terraform Libvirt provider](https://github.com/dmacvicar/terraform-provider-libvirt) is very, very cool. It's also used by `openshift-install` for its Libvirt-based deployments, so it supports everything needed to deploy OKD nodes. Most importantly, I can use Terraform to supply the VMs with their Ignition configs, which means I don't have to worry about passing kernel args manually or setting up a PXE server to get things going like the official OKD docs would have you do. Terraform also makes it easy to tear down the cluster and reset in case something goes wrong.
+
+## Post-Bootstrap One-Time Setup
+
+### Storage with Rook and Ceph
+
+I deploy a Ceph cluster into OKD using Rook. The Rook configuration deploys OSDs on top of the 4TiB HDDs assigned to each worker. I deploy an erasure-coded CephFS pool (6+2) for RWX workloads and a 3x replica block pool for RWO workloads.
+
+### Monitoring and Alerting
+
+OKD comes with a very comprehensive monitoring and alerting suite, and it would be a shame not to take advantage of it. I set up an Alertmanager webhook to send any alerts to a [small program I wrote that posts the alerts to Discord](https://github.com/SriRamanujam/alertmanager-discord-bridge).
+
+I also deploy a Prometheus + Grafana set up into the cluster that collects metrics from the various hypervisors and supporting infrastructure VMs. I use Grafana's built-in Discord alerting mechanism to post those alerts.
+
+### LoadBalancer with MetalLB
+
+[MetalLB](https://metallb.universe.tf) is a piece of fantastic software that allows on-prem or otherwise non-public-cloud Kubernetes clusters to enjoy the luxury of `LoadBalancer` type services. It's dead simple to set up and makes you feel you're in a real datacenter. I deploy several workloads that don't use standard HTTP and so can't be deployed behind a `Route`. Without MetalLB, I wouldn't be able to deploy these workloads on OKD at all but with it, I can!
+
+## Software I Run
+
+I maintain an ansible playbook that handles deploying my workloads into the cluster. I prefer Ansible over other tools like Helm because it has more robust capabilities to store secrets, I find its templating capabilities more flexible and powerful than Helm's (especially when it comes to inlining config files into config maps or creating templated Dockerfiles for BuildConfigs), and because I am already familiar with Ansible and know how it works.
+
+* [paperless-ng](https://github.com/jonaswinkler/paperless-ng) - A document organizer that uses machine learning to automatically classify and organize
+* [bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Password manager
+* [Jellyfin](https://jellyfin.org/) - Media management
+* [Samba](https://www.samba.org/) - I joined a StatefulSet to my AD domain and it serves an authenticated SMB share
+* [Netbox](https://github.com/netbox-community/netbox) - Infrastructure management tool
+* [Quassel](https://quassel-irc.org) - IRC bouncer
+* [Ukulele](https://github.com/Frederikam/ukulele) - Bot that plays music into Discord channels
+* RPM and deb package repos for internal packages

--- a/source/guides/2021-03-24-Homelab-UPI-vrutkovs.html.markdown
+++ b/source/guides/2021-03-24-Homelab-UPI-vrutkovs.html.markdown
@@ -1,0 +1,73 @@
+---
+title: Vadim's homelab
+---
+
+This describes the resources used by OKD after perfoming an installation
+to make it similar to my homelab setup.
+
+## Compute
+
+* 1 Ubiquity EdgeRouter ER-X
+  * runs DHCP (embedded), custom DNS server via AdGuard
+  * [pic](https://dl.vrutkovs.eu/public/homelab/erx.jpg)
+* 1 NAS/Bastion host
+  * haproxy for loadbalancer
+  * ceph cluster for PVs
+  * NFS server for shared data
+  * [pic](https://dl.vrutkovs.eu/public/homelab/neptr-gumball.jpg)
+* 1 control plane
+  * Intel i5 CPU, 16+4 GB RAM
+  * 120 GB NVME disk
+  * [pic](https://dl.vrutkovs.eu/public/homelab/bmo.jpg)
+* 1 compute nodes
+  * Lenovo X220 laptop
+  * [pic](https://dl.vrutkovs.eu/public/homelab/neptr-gumball.jpg)
+
+## Router setup
+Once nodes have booted assign static IPs using MAC pinning.
+
+EdgeRouter has dnsmasq to support custom DNS entries, but I wanted to have a network-wide ad filtering
+ and DNS-over-TLS for free, so I followed [this guide](https://medium.com/@casonadams/edgerouter-x-adguardhome-b9d453f5725b) 
+ to install [AdGuard Home](https://adguard.com/en/adguard-home/overview.html) on the router.
+ This gives a fancy UI for DNS rewrites and gives a useful stats about the nodes on the network.
+
+## NAS/Bastion setup
+HAProxy setup is fairly standard - see [ocp4-helpernode](https://github.com/RedHatOfficial/ocp4-helpernode) for idea.
+
+Along with (fairly standard) NFS server I also run a single node Ceph cluster, so that I could benefit 
+from CSI / autoprovision / snapshots etc.
+
+## Installation
+
+Currently "single node install" requires a dedicated throwaway bootstrap node, so I used future compute node (x220 laptop)
+as a bootstrap node. Once master was installed, the laptop was re-provisioned to become a compute node.
+
+## Upgrading
+
+Since I use a single master install, upgrades are bit complicated. Both nodes are labelled as workers, so upgrading those is not an issue.
+Upgrading single master is tricky, so I use [this script](https://github.com/vrutkovs/okd-installer/blob/master/manifests/singlenode/upgrade-master.sh) to pivot the node into expected master ignition content, which runs `rpm-ostree rebase <new content>`. This script needs to be cancelled before it starts installing OS extensions (NetworkManager-ovs etc.) as its necessary.
+
+This issue as a class would be addressed in 4.8.
+
+## Useful software
+
+[Grafana operator](https://operatorhub.io/operator/grafana-operator) is incredibly useful to setup monitoring.
+This operator helps me to define a configuration for various datasources (i.e. [Promtail+Loki](https://grafana.com/oss/loki/)) and control dashboard source code using CRs.
+
+[SnapScheduler](https://operatorhub.io/operator/snapscheduler) makes periodic snapshots of some PVs so that risky changes could be reverted.
+
+[Tekton](https://operatorhub.io/operator/tektoncd-operator) operator is helping me to run a few clean up jobs in cluster periodically.
+Most useful pipeline I've been using is running `oc adm must-gather` on this cluster, unpacking it and storing it in Git. This helps me keep track of changes in the cluster in a git repo - and, unlike gitops solution like ArgoCD - I can still tinker with things in the console.
+
+Other useful software running in my cluster:
+
+* [Gitea](https://gitea.io) - git server
+* [HomeAssistant](https://home-assistant.io/) - controls smart home devices
+* [BitWarden_rs](https://github.com/dani-garcia/bitwarden_rs) - password storage
+* [Minio](https://min.io) - S3-like storage
+* [Nextcloud](https://nextcloud.com) - file sync software
+* [Navidrome](https://www.navidrome.org) - music server
+* [MiniFlux](https://miniflux.app) - RSS reader
+* [Matrix Synapse](https://matrix.org) - federated chat app
+* [Pleroma](https://pleroma.social) - federated microblogging app
+* [Wallabag](https://www.wallabag.it) - Read-It-Later app

--- a/source/guides/2021-03-24-SingleNode-cgruver.html.markdown
+++ b/source/guides/2021-03-24-SingleNode-cgruver.html.markdown
@@ -1,0 +1,16 @@
+---
+title: Single Node OKD Installation
+---
+
+This document outlines how to deploy a single node OKD cluster using virt.
+
+## Requirements
+
+- Host with a minimal CentOS Stream, Fedora, or CentOS-8 installed (*do not create a /home filesystem*)
+- Monitor, mouse, and keyboard attached to the host
+- Static IP for the host
+- The following packages installed: virt, wget, git, net-tools, bind, bind-utils, bash-completion, rsync, libguestfs-tools, virt-install, epel-release, libvirt-devel, httpd-tools, snf, nginx
+
+## Procedure 
+
+For the complete procedure, please see [Building an OKD4 single node cluster with minimal resources](https://cgruver.github.io/okd4-single-node-cluster)

--- a/source/guides/2021-03-24-vSphere-IPI-default-deployment.html.markdown
+++ b/source/guides/2021-03-24-vSphere-IPI-default-deployment.html.markdown
@@ -1,0 +1,41 @@
+---
+title: vSphere IPI Deployment
+authors:
+  - "@lobziik"
+last-updated: "2021-03-24"
+okd-version: "4.7"
+---
+
+This describes the resources used by OKD after perfoming an installation
+using the required options for the installer.
+
+## Infrastructure
+
+### Compute
+All vms stored within folder described above and tagged with tag created by installer.
+
+* 3 control plane vms (name format: `{cluster name}-{generated cluster id}-master-{0,1,2}`)
+  * 4 vCPU
+  * 16 GB RAM
+  * 120 GB storage
+  
+* 3 worker vms (name format: `{cluster name}-{generated cluster id}-master-{generated worker id}`)
+  * 2 vCPU
+  * 8 GB RAM
+  * 120 GB storage
+
+### Networking
+
+Should be set up by user. Installer doesn't create anything there. Network name should be provided as installer argument.
+
+### Miscellaneous
+
+* tag category with format `openshift-{cluster name}-{generated cluster id}`
+* tag with format `{cluster name}-{generated cluster id}`
+* folder with title format `{cluster name}-{generated cluster id}`
+* disabled virtual machine with name `{cluster name}-rhcos-{generated cluster id}` which using as template for further scaling
+
+## Deployment
+
+See the [OKD documentation](https://docs.okd.io/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html)
+to proceed with deployment.

--- a/source/guides/2021-03-24-vSphere-UPI-prerequisites.html.markdown
+++ b/source/guides/2021-03-24-vSphere-UPI-prerequisites.html.markdown
@@ -1,0 +1,513 @@
+---
+title: Prerequites for vSphere UPI
+---
+
+In this example I describe the setup of a DNS/DHCP server and a Load Balancer on a Raspberry PI microcomputer. The instructions most certainly will also work for other environments.
+
+I use Raspberry Pi OS (debian based).
+
+## IP Addresses of components in this example
+* Homelab subnet: **192.168.178.0/24**
+* DSL router/gateway: **192.168.178.1**
+* IP address of Raspberry Pi (DHCP/DNS/Load Balancer): **192.168.178.5**
+* local domain: **homelab.net**
+* local cluster (name: c1) domain: **c1.homelab.net**
+* DHCP range: 192.168.178.40 ... 192.168.178.199
+* Static IPs for OKD's bootstrap, masters and workers
+
+## Upgrade Raspberry Pi
+
+```
+sudo apt-get update
+sudo apt-get upgrade
+sudo reboot
+```
+
+## Set static IP address on Raspberry Pi
+
+Add this:
+```
+interface eth0
+static ip_address=192.168.178.5/24
+static routers=192.168.178.1
+static domain_name_servers=192.168.178.5 8.8.8.8
+```
+to 
+
+/etc/dhcpcd.conf
+
+## DHCP
+Ensure that no other DHCP servers are activated in the network of your homelab e.g. in your internet router.
+
+The DHCP server in this example is setup with DDNS (Dynamic DNS) enabled.
+
+### Install
+
+```
+sudo apt-get install isc-dhcp-server
+```
+
+### Configure
+
+Enable DHCP server for IPv4 on eth0: 
+
+/etc/default/isc-dhcp-server
+```
+INTERFACESv4="eth0"
+INTERFACESv6=""
+```
+
+/etc/dhcp/dhcpd.conf
+```
+# dhcpd.conf
+#
+
+####################################################################################
+# Configuration for Dynamic DNS (DDNS) updates                                     #
+# Clients requesting an IP and sending their hostname for domain *.homelab.net     #
+# will be auto registered in the DNS server.                                       #
+####################################################################################
+ddns-updates on;
+ddns-update-style standard;
+
+# This option points to the copy rndc.key we created for bind9.
+include "/etc/bind/rndc.key";
+
+allow unknown-clients;
+use-host-decl-names on;
+default-lease-time 300; # 5 minutes
+max-lease-time 300;     # 5 minutes
+
+# homelab.net DNS zones
+zone homelab.net. {
+  primary 192.168.178.5; # This server is the primary DNS server for the zone
+  key rndc-key;       # Use the key we defined earlier for dynamic updates
+}
+zone 178.168.192.in-addr.arpa. {
+  primary 192.168.178.5; # This server is the primary reverse DNS for the zone
+  key rndc-key;       # Use the key we defined earlier for dynamic updates
+}
+
+ddns-domainname "homelab.net.";
+ddns-rev-domainname "in-addr.arpa.";
+####################################################################################
+
+
+####################################################################################
+# Basic configuration                                                              #
+####################################################################################
+# option definitions common to all supported networks...
+default-lease-time 300;
+max-lease-time     300;
+
+# If this DHCP server is the official DHCP server for the local
+# network, the authoritative directive should be uncommented.
+authoritative;
+
+# Parts of this section will be put in the /etc/resolv.conf of your hosts later
+option domain-name "homelab.net";
+option routers 192.168.178.1;
+option subnet-mask 255.255.255.0;
+option domain-name-servers 192.168.178.5;
+
+subnet 192.168.178.0 netmask 255.255.255.0 {
+  range 192.168.178.40 192.168.178.199;
+}
+####################################################################################
+
+
+####################################################################################
+# Static IP addresses                                                              #
+# (Replace the MAC addresses here with the ones you set in vsphere for your vms)   #
+####################################################################################
+group {
+  host bootstrap {
+      hardware ethernet 00:1c:00:00:00:00;
+      fixed-address 192.168.178.200;
+  }
+
+  host master0 {
+      hardware ethernet 00:1c:00:00:00:10;
+      fixed-address 192.168.178.210;
+  }
+
+  host master1 {
+      hardware ethernet 00:1c:00:00:00:11;
+      fixed-address 192.168.178.211;
+  }
+
+  host master2 {
+      hardware ethernet 00:1c:00:00:00:12;
+      fixed-address 192.168.178.212;
+  }
+
+  host worker0 {
+      hardware ethernet 00:1c:00:00:00:20;
+      fixed-address 192.168.178.220;
+  }
+
+  host worker1 {
+      hardware ethernet 00:1c:00:00:00:21;
+      fixed-address 192.168.178.221;
+  }
+  
+  host worker2 {
+      hardware ethernet 00:1c:00:00:00:22;
+      fixed-address 192.168.178.222;
+  }  
+}
+```
+
+## DNS
+
+### Install
+
+```
+sudo apt install bind9 dnsutils
+```
+
+### Basic configuration
+
+/etc/bind/named.conf.options
+```
+include "/etc/bind/rndc.key";
+
+acl internals {
+    // lo adapter
+    127.0.0.1;
+
+    // CIDR for your homelab network
+    192.168.178.0/24;
+};
+
+options {
+        directory "/var/cache/bind";
+
+        // If there is a firewall between you and nameservers you want
+        // to talk to, you may need to fix the firewall to allow multiple
+        // ports to talk.  See http://www.kb.cert.org/vuls/id/800113
+
+        // If your ISP provided one or more IP addresses for stable
+        // nameservers, you probably want to use them as forwarders.
+        // Uncomment the following block, and insert the addresses replacing
+        // the all-0's placeholder.
+
+        forwarders {
+          8.8.8.8;
+          8.8.4.4;
+        };
+        forward only;
+
+        //========================================================================
+        // If BIND logs error messages about the root key being expired,
+        // you will need to update your keys.  See https://www.isc.org/bind-keys
+        //========================================================================
+        dnssec-validation no;
+
+        listen-on-v6 { none; };
+        auth-nxdomain no;
+        listen-on port 53 { any; };
+
+        // Allow queries from my Homelab and also from Wireguard Clients.
+        allow-query { internals; };
+        allow-query-cache { internals; };
+        allow-update { internals; };
+        recursion yes;
+        allow-recursion { internals; };
+        allow-transfer { internals; };
+
+        dnssec-enable no;
+
+        check-names master ignore;
+        check-names slave ignore;
+        check-names response ignore;
+};
+```
+
+/etc/bind/named.conf.local
+```
+#include "/etc/bind/rndc.key";
+
+//
+// Do any local configuration here
+//
+
+// Consider adding the 1918 zones here, if they are not used in your
+// organization
+//include "/etc/bind/zones.rfc1918";
+
+# All devices that don't belong to the OKD cluster will be maintained here.
+zone "homelab.net" {
+   type master;
+   file "/etc/bind/forward.homelab.net";
+   allow-update { key rndc-key; };
+};
+
+zone "c1.homelab.net" {
+   type master;
+   file "/etc/bind/forward.c1.homelab.net";
+   allow-update { key rndc-key; };
+};
+
+zone "178.168.192.in-addr.arpa" {
+   type master;
+   notify no;
+   file "/etc/bind/178.168.192.in-addr.arpa";
+   allow-update { key rndc-key; };
+};
+```
+
+Zone file for **homlab.net**:
+/etc/bind/forward.homelab.net
+```
+;
+; BIND data file for local loopback interface
+;
+$TTL    604800
+@       IN      SOA     homelab.net. root.homelab.net. (
+                              2         ; Serial
+                         604800         ; Refresh
+                          86400         ; Retry
+                        2419200         ; Expire
+                         604800 )       ; Negative Cache TTL
+;
+@       IN      NS      homelab.net.
+@       IN      A       192.168.178.5
+@       IN      AAAA    ::1
+```
+
+
+The name of the next file depends on the subnet that is used:
+
+/etc/bind/178.168.192.in-addr.arpa
+```
+$TTL 1W
+@ IN SOA ns1.homelab.net. root.homelab.net. (
+                                2019070742 ; serial
+                                10800      ; refresh (3 hours)
+                                1800       ; retry (30 minutes)
+                                1209600    ; expire (2 weeks)
+                                604800     ; minimum (1 week)
+                                )
+                        NS      ns1.homelab.net.
+
+200                     PTR     bootstrap.c1.homelab.net.
+
+210                     PTR     master0.c1.homelab.net.
+211                     PTR     master1.c1.homelab.net.
+212                     PTR     master2.c1.homelab.net.
+
+220                     PTR     worker0.c1.homelab.net.
+221                     PTR     worker1.c1.homelab.net.
+222                     PTR     worker2.c1.homelab.net.
+
+5                       PTR     api.c1.homelab.net.
+5                       PTR     api-int.c1.homelab.net.
+```
+
+### DNS records for OKD 4
+
+Zone file for **c1.homelab.net** (our OKD 4 cluster will be in this domain):
+
+/etc/bind/forward.c1.homelab.net
+```
+;
+; BIND data file for local loopback interface
+;
+$TTL    604800
+@       IN      SOA     c1.homelab.net. root.c1.homelab.net. (
+                              2         ; Serial
+                         604800         ; Refresh
+                          86400         ; Retry
+                        2419200         ; Expire
+                         604800 )       ; Negative Cache TTL
+;
+@       IN      NS      c1.homelab.net.
+@       IN      A       192.168.178.5
+@       IN      AAAA    ::1
+
+load-balancer IN A      192.168.178.5
+
+bootstrap IN    A       192.168.178.200
+
+master0 IN      A       192.168.178.210
+master1 IN      A       192.168.178.211
+master2 IN      A       192.168.178.212
+
+worker0 IN      A       192.168.178.220
+worker1 IN      A       192.168.178.221
+worker2 IN      A       192.168.178.222
+worker3 IN      A       192.168.178.223
+
+*.apps.c1.homelab.net.  IN CNAME load-balancer.c1.homelab.net.
+api-int.c1.homelab.net. IN CNAME load-balancer.c1.homelab.net.
+api.c1.homelab.net.     IN CNAME load-balancer.c1.homelab.net.
+```
+
+## Set file permissions
+
+For dynamic DNS (ddns) to work you should do this:
+```
+sudo chown -R bind:bind /etc/bind
+```
+
+## Load Balancer
+
+### Install
+
+```
+sudo apt-get install haproxy
+```
+
+### Configure
+
+/etc/haproxy/haproxy.cfg
+```
+global
+        log /dev/log    local0
+        log /dev/log    local1 notice
+        chroot /var/lib/haproxy
+        stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
+        stats timeout 30s
+        user haproxy
+        group haproxy
+        daemon
+
+        # Default SSL material locations
+        ca-base /etc/ssl/certs
+        crt-base /etc/ssl/private
+
+        # Default ciphers to use on SSL-enabled listening sockets.
+        # For more information, see ciphers(1SSL). This list is from:
+        #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+        # An alternative list with additional directives can be obtained from
+        #  https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=haproxy
+        ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
+        ssl-default-bind-options no-sslv3
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        timeout connect 20000
+        timeout client  10000
+        timeout server  10000
+        errorfile 400 /etc/haproxy/errors/400.http
+        errorfile 403 /etc/haproxy/errors/403.http
+        errorfile 408 /etc/haproxy/errors/408.http
+        errorfile 500 /etc/haproxy/errors/500.http
+        errorfile 502 /etc/haproxy/errors/502.http
+        errorfile 503 /etc/haproxy/errors/503.http
+        errorfile 504 /etc/haproxy/errors/504.http
+
+
+# You can see the stats and observe OKD's bootstrap process by opening
+# http://<IP>:4321/haproxy?stats
+listen stats
+    bind :4321
+    mode            http
+    log             global
+    maxconn 10
+
+    timeout client  100s
+    timeout server  100s
+    timeout connect 100s
+    timeout queue   100s
+
+    stats enable
+    stats hide-version
+    stats refresh 30s
+    stats show-node
+    stats auth admin:password
+    stats uri  /haproxy?stats
+
+
+frontend openshift-api-server
+    bind *:6443
+    default_backend openshift-api-server
+    mode tcp
+    option tcplog
+
+backend openshift-api-server
+    balance source
+    mode tcp
+    server bootstrap bootstrap.c1.homelab.net:6443 check
+    server master0 master0.c1.homelab.net:6443 check
+    server master1 master1.c1.homelab.net:6443 check
+    server master2 master2.c1.homelab.net:6443 check
+
+
+frontend machine-config-server
+    bind *:22623
+    default_backend machine-config-server
+    mode tcp
+    option tcplog
+
+backend machine-config-server
+    balance source
+    mode tcp
+    server bootstrap bootstrap.c1.homelab.net:22623 check
+    server master0 master0.c1.homelab.net:22623 check
+    server master1 master1.c1.homelab.net:22623 check
+    server master2 master2.c1.homelab.net:22623 check
+
+
+frontend ingress-http
+    bind *:80
+    default_backend ingress-http
+    mode tcp
+    option tcplog
+
+backend ingress-http
+    balance source
+    mode tcp
+    server master0 master0.c1.homelab.net:80 check
+    server master1 master1.c1.homelab.net:80 check
+    server master2 master2.c1.homelab.net:80 check
+
+    server worker0 worker0.c1.homelab.net:80 check
+    server worker1 worker1.c1.homelab.net:80 check
+    server worker2 worker2.c1.homelab.net:80 check
+    server worker3 worker3.c1.homelab.net:80 check
+
+
+frontend ingress-https
+    bind *:443
+    default_backend ingress-https
+    mode tcp
+    option tcplog
+
+backend ingress-https
+    balance source
+    mode tcp
+
+    server master0 master0.c1.homelab.net:443 check
+    server master1 master1.c1.homelab.net:443 check
+    server master2 master2.c1.homelab.net:443 check
+
+    server worker0 worker0.c1.homelab.net:443 check
+    server worker1 worker1.c1.homelab.net:443 check
+    server worker2 worker2.c1.homelab.net:443 check
+    server worker3 worker3.c1.homelab.net:443 check
+```
+
+## Reboot and check status
+
+Reboot Raspberry Pi:
+```
+sudo reboot
+```
+
+Check status of DNS/DHCP server and Load Balancer:
+```
+sudo systemctl status haproxy.service
+sudo systemctl status isc-dhcp-server.service
+sudo systemctl status bind9
+```
+
+## Proxy (if on a private network)
+
+If the cluster will sit on a private network, you'll need a proxy for outgoing traffic, both for the install process and for regular operation. In the case of the former, the installer needs to pull containers from the external registires. In the case of the latter, the proxy is needed when applicaton containers need access to the outside world (e.g. yum installs, external code repositories like gitlab, etc.)
+
+The proxy should be configured to accept conections from the IP subnet for your cluster. A simple proxy to use for this purpose is [squid](http://www.squid-cache.org)

--- a/source/guides/2021-03-24-vSphere-automated-testing-system.html.markdown
+++ b/source/guides/2021-03-24-vSphere-automated-testing-system.html.markdown
@@ -1,0 +1,83 @@
+---
+title: Implementing an Automated Installation Solution for OKD on vSphere with User Provisioned Infrastructure (UPI)
+---
+
+## Introduction 
+
+It's possible to completely automate the process of installing OpenShift/OKD on vSphere with User Provisioned Infrastructure by chaining together the various functions of [OCT](https://github.com/JaimeMagiera/oct) via a wrapper script. 
+
+## Steps
+
+1. Deploy the DNS, DHCP, and load balancer infrastructure outlined in the [Prerequisites](#Prerequisites) section.
+2. Create an install-config.yaml.template file based on the format outlined in the section [Sample install-config.yaml file for VMware vSphere](https://docs.okd.io/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-config-yaml_installing-vsphere) of the OKD docs. Do not add a pull secret. The script will query you for one or it will insert a default one if you use the --auto-secret flag. 
+3. Create a [wrapper script](#Wrapper-Script) that:
+   * Installs the desired FCOS image
+   * Downloads the oc and openshift-installer binaries for your desired release version
+   * Generates and modifies the ignition files appropriately
+   * Builds the cluster nodes
+   * Triggers the installation process. 
+
+## Prerequisites
+
+### DNS
+
+* 1 entry for the bootstrap node of the format bootstrap.[cluster].domain.tld
+* 3 entries for the master nodes of the form master-[n].[cluster].domain.tld
+* An entry for each of the desired worker nodes in the form worker-[n].[cluster].domain.tld
+* 1 entry for the API endpoint in the form api.[cluster].domain.tld
+* 1 entry for the API internal endpoint in the form api-int.[cluster].domain.tld
+* 1 wilcard entry for the Ingress endpoint in the form \*.apps.[cluster].domain.tld
+
+### DHCP
+### Load Balancer
+
+vSphere UPI requires the use of a load balancer. There needs to be two pools.
+
+* API: This pool should contain your master nodes. 
+* Ingress: This pool should contain your worker nodes. 
+
+### Proxy (Optional)
+
+If the cluster will sit on a private network, you'll need a proxy for outgoing traffic, both for the install process and for regular operation. In the case of the former, the installer needs to pull containers from the external registires. In the case of the latter, the proxy is needed when applicaton containers need access to the outside world (e.g. yum installs, external code repositories like gitlab, etc.) 
+
+The proxy should be configured to accept conections from the IP subnet for your cluster. A simple proxy to use for this purpose is [squid](http://www.squid-cache.org) 
+
+## Wrapper Script
+
+``` bash
+#!/bin/bash
+
+masters_count=3
+workers_count=2
+template_url="https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210314.2.0/x86_64/fedora-coreos-33.20210314.2.0-vmware.x86_64.ova"
+template_name="fedora-coreos-33.20210201.2.1-vmware.x86_64"		
+library="Linux ISOs"
+cluster_name="mycluster"
+cluster_folder="/MyVSPHERE/vm/Linux/OKD/mycluster"
+network_name="VM Network"
+install_folder=`pwd`
+
+# Import the template
+./oct.sh --import-template --library "${library}" --template-url "${template_url}"
+
+# Install the desired OKD tools
+oct.sh --install-tools --release 4.6
+
+# Launch the prerun to generate and modify the ignition files
+oct.sh --prerun --auto-secret
+
+# Deploy the nodes for the cluster with the appropriate ignition data
+oct.sh --build --template-name "${template_name}" --library "${library}" --cluster-name "${cluster_name}" --cluster-folder "${cluster_folder}" --network-name "${network_name}" --installation-folder "${install_folder}" --master-node-count ${masters_count} --worker-node-count ${workers_count} 
+
+# Turn on the cluster nodes
+oct.sh --cluster-power on --cluster-name "${cluster_name}"  --master-node-count ${masters_count} --worker-node-count ${workers_count}
+
+# Run the OpenShift installer 
+bin/openshift-install --dir=$(pwd) wait-for bootstrap-complete  --log-level=info
+
+```
+
+## Future Updates
+* Generating the install-config template
+* Pull directly from FCOS release feed
+

--- a/source/installation.html.erb
+++ b/source/installation.html.erb
@@ -1,0 +1,45 @@
+---
+title: Installation
+---
+
+<% content_for :header do %>
+    <h1 class="animated fadeInDown delay">
+      OKD Installation
+    </h1>
+    <p class="animated fadeInUp delay">
+      Instructions, Community Guides, ...
+    </p>
+<% end %>
+
+<div class="crumbs border_bottom">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <ul>
+          <li>
+            <a href="/index.html">Home</a>
+          </li>
+          <li>/</li>
+          <li>
+            <a href="/installation.html">OKD Installation</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row info_title wow">
+  <div class="vertical_line">
+    <div class="circle_bottom"></div>
+  </div>
+  <div class="info_vertical">
+    <h1> <span>Install Documentation</span> </h1>
+  </div>
+  <div class="container">
+    <ul>
+      <li><a href="https://docs.okd.io/latest/installing/index.html" target="_blank">Latest official installation documentation</a></li>
+      <li><a href="https://github.com/openshift/okd/" target="_blank">OKD community repository (FAQ, Report Issues, etc.)</a></li>
+    </ul>
+  </div>
+</div>

--- a/source/installation.html.erb
+++ b/source/installation.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Installation
+blog: guides
 ---
 
 <% content_for :header do %>
@@ -40,6 +41,19 @@ title: Installation
     <ul>
       <li><a href="https://docs.okd.io/latest/installing/index.html" target="_blank">Latest official installation documentation</a></li>
       <li><a href="https://github.com/openshift/okd/" target="_blank">OKD community repository (FAQ, Report Issues, etc.)</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="row info_title wow">
+  <div class="info_vertical">
+    <h1> <span>Deployment Guides</span> </h1>
+  </div>
+  <div class="container">
+    <ul>
+    <% blog.articles.each do |article| %>
+      <li><%= link_to article.title, article %></li>
+    <% end %>
     </ul>
   </div>
 </div>

--- a/source/layouts/_navbar.erb
+++ b/source/layouts/_navbar.erb
@@ -19,7 +19,7 @@
             <a href="https://github.com/openshift/okd/discussions">COMMUNITY</a>
           </li>                   
           <li>
-            <a href="https://github.com/elmiko/okd-deployment-configuration-guides#okd-deployment-configuration-guides">GUIDES</a>
+            <%= link_to "RECIPES", "/recipes.html" %>
           </li>
           <li>
             <!-- Place this tag where you want the button to render. -->

--- a/source/layouts/_navbar.erb
+++ b/source/layouts/_navbar.erb
@@ -7,7 +7,7 @@
             <a href="/#v4"><nobr>WHAT IS OKD?</nobr></a>
           </li>
           <li>
-            <a href="https://github.com/openshift/okd/">INSTALLATION</a>
+            <a href="/installation.html">INSTALLATION</a>
           </li>      
           <li>
             <a href="https://docs.okd.io/">DOCUMENTATION</a>

--- a/source/layouts/guides.erb
+++ b/source/layouts/guides.erb
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title><%= current_page.data.title || settings.site_title %></title>
+    <meta name="description" content="<%= current_page.data.description || "The next generation open source app hosting platform by Red Hat" %>">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="google-site-verification" content="9jyGvNki3NSELTYJ7t_XbF-YQZ8jjfm7LqQQGNq4SSg">
+    <%= stylesheet_link_tag "style.css", :media => "screen, print", :type => "text/css" %>
+    <%= stylesheet_link_tag "theme-responsive.css", :media => "screen", :type => "text/css" %>
+    <%= stylesheet_link_tag "custom.css", :media => "screen", :type => "text/css" %>
+    <%= stylesheet_link_tag "highlighting.css", :media => "screen", :type => "text/css" %>
+    <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700", :media => "screen", :type => "text/css" %>
+    <%= favicon_tag "/img/icons/apple-touch-icon.png", :rel => "apple-touch-icon-precomposed" %>
+    <%= favicon_tag "/img/icons/favicon.png" %>
+    <!--[if IE]>
+      <%= stylesheet_link_tag "ie/ie.css", :media => "screen", :type => "text/css" %>
+    <![endif]-->
+    <!--[if lte IE 8]>
+      <%= javascript_include_tag "responsive/html5shiv.js" %>
+      <%= javascript_include_tag "responsive/respond.js" %>
+    <![endif]-->
+    <%= partial "layouts/tracking" %>
+
+    <meta charset="utf-8" />
+    <meta http-equiv='X-UA-Compatible' content='ie=edge' />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  </head>
+
+  <body>
+    <div class="layout-wide" id="layout">
+      <header class="index_static">
+        <%= content_for?(:navbar) ? yield_content(:navbar) : (partial "layouts/navbar") %>
+        <section class="content_info">
+          <div class="bg_parallax image_03_parallax"></div>
+          <section class="opacy_bg_02 paddings">
+            <div class="container">
+              <div class="row">
+                <div class="col-md-12">
+                  <div class="logo wow fadeIn delay">
+                    <a href="/index.html" title="Back to Home">
+                      <%= image_tag 'okd_logo.svg', {:alt => 'OKD logo', :class => 'logo_img'} %>
+                    </a>
+                  </div>
+                  <%= yield_content(:header) %>
+                </div>
+              </div>
+            </div>
+          </section>
+        </section>
+      </header>
+
+      <div id="main" role="main">
+        <%= yield %>
+      </div>
+
+      <%= partial "layouts/footer" %>
+    </div>
+
+    <%= javascript_include_tag "jquery.js" %>
+    <%= javascript_include_tag "search.js" %>
+    <%= javascript_include_tag "nav/tinynav.js" %>
+    <%= javascript_include_tag "nav/superfish.js" %>
+    <%= javascript_include_tag "nav/hoverIntent.js" %>
+    <%= javascript_include_tag "totop/jquery.ui.totop.js" %>
+    <%= javascript_include_tag "rs-plugin/js/jquery.themepunch.tools.min.js" %>
+    <%= javascript_include_tag "rs-plugin/js/jquery.themepunch.revolution.min.js" %>
+    <%= javascript_include_tag "carousel/owl.carousel.js" %>
+    <%= javascript_include_tag "fancybox/jquery.fancybox.pack.js" %>
+    <%= javascript_include_tag "gallery/modernizr.custom.26633.js" %>
+    <%= javascript_include_tag "gallery/jquery.gridrotator.js" %>
+    <%= javascript_include_tag "team/modernizr.custom.63321.js" %>
+    <%= javascript_include_tag "team/jquery.catslider.js" %>
+    <!-- <%= javascript_include_tag "filters/jquery.isotope.js" %> -->
+    <%= javascript_include_tag "filters/isotope.pkgd.js" %> <!-- Isotope PACKAGED v3.0.6 -->
+    <%= javascript_include_tag "theme-options/theme-options.js" %>
+    <%= javascript_include_tag "theme-options/jquery.cookies.js" %>
+    <%= javascript_include_tag "twitter/jquery.tweet.js" %>
+    <%= javascript_include_tag "animations/wow.min.js" %>
+    <%= javascript_include_tag "parallax/jquery.inview.js" %>
+    <%= javascript_include_tag "parallax/nbw-parallax.js" %>
+    <%= javascript_include_tag "bootstrap/bootstrap.js" %>
+    <%= javascript_include_tag "main.js" %>
+    <%= yield_content(:javascript) %>
+
+    <!-- Google Remarekting -->
+    <script type="text/javascript">
+    /* <![CDATA[ */
+    var google_conversion_id = 1007064360;
+    var google_custom_params = window.google_tag_params;
+    var google_remarketing_only = true;
+    /* ]]> */
+    </script>
+    <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+    </script>
+    <noscript>
+    <div style="display:inline;">
+    <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/1007064360/?value=0&amp;guid=ON&amp;script=0"/>
+    </div>
+    </noscript>
+    <!-- Track tagged outbound Links -->
+    <script type="text/javascript">
+    $(document).ready(function(){
+      $('.analytics').click(function(e){
+        e.preventDefault();
+        trackOutboundLink($(this).attr('href'));
+      });
+    });
+    </script>
+    <!-- Place this tag right after the last button or just before your close body tag. -->
+    <script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This change adds an installation page to the site. The new page follows a similar pattern as the blog landing page, and contains links to the official docs as well as the content from the [okd deployment configuration guides](https://github.com/elmiko/okd-deployment-configuration-guides) repository.