### PR TITLE
add local container server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ should be able to preview your changes at http://localhost:4567
 bundle exec middleman server
 ```
 
+### Developing with a local container
+
+To test a local version of the site using a containerized builder/server, please
+see the [local containerized server instructions](hack/local-containerized-server/readme.md).
+
 ## Create Blog article
 
 Create a file in the directory **source/blog**. 

--- a/hack/local-container-server/Dockerfile.server
+++ b/hack/local-container-server/Dockerfile.server
@@ -1,0 +1,14 @@
+FROM quay.io/centos7/ruby-27-centos7
+
+ADD . /opt/app-root/src/
+
+USER root
+
+WORKDIR /opt/app-root/src
+
+RUN gem install bundler && \
+    bundle install
+
+EXPOSE 4567
+
+CMD ["/opt/rh/rh-ruby27/root/usr/local/bin/bundle", "exec", "middleman", "server"]

--- a/hack/local-container-server/readme.md
+++ b/hack/local-container-server/readme.md
@@ -1,0 +1,30 @@
+# Running a Containerized Middleman Server for Local Testing
+
+These instructions will show you how to run a local container to test the OKD
+community website. This process should be used in situations where installing
+the site build dependencies is troublesome.
+
+This document assumes you have [Podman](https://podman.io) available on your
+system. This process _should_ work with [Docker](https://docker.com), but you
+will need to modify the instructions and `server.sh` script accordingly.
+
+You should perform these actions from the root from the project repository.
+
+1. Create a local container to run the Middleman server. This will create a
+   container with all the necessary dependencies to run the site. It will
+   copy files from the site directory, but these will be overwritten with your
+   local changes when you run the `server.sh` script. You will need to rebuild
+   this container if you add dependencies to the Gemfile.
+   ```
+   podman build -t okdio-server -f hack/local-container-server/Dockerfile.server .
+   ```
+
+2. Run the server using the `server.sh` script. This script will handle mounting
+   the local content files and exposing port `4567` on the localhost. If you
+   do not have a local `data/participants.yml` file, this script will create an
+   empty file for you.
+   ```
+   ./hack/local-container-server/server.sh
+   ```
+
+3. Open your web browser to [localhost:4567](http://localhost:4567).

--- a/hack/local-container-server/server.sh
+++ b/hack/local-container-server/server.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -ex
+
+participants_file=data/participants.yml
+if [ ! -e $participants_file ]
+then
+    echo "participants: []" > $participants_file
+fi
+
+server_image=localhost/okdio-server:latest
+
+cwd=$(pwd)
+podman run --rm -it \
+    -p 4567:4567 \
+    -v $cwd/config.rb:/opt/app-root/src/config.rb:Z \
+    -v $cwd/data:/opt/app-root/src/data:Z \
+    -v $cwd/source:/opt/app-root/src/source:Z \
+    -v $cwd/briefings:/opt/app-root/src/briefings:Z \
+    $server_image


### PR DESCRIPTION
This change adds a dockerfile, a script, and some instructions for
running the site locally as a container.

I was not able to make the instructions in the readme work on Fedora 34 workstation. i created this workaround after a few hours of pulling hair.