### PR TITLE
Correct CRC download links

### DIFF
--- a/source/crc.html.erb
+++ b/source/crc.html.erb
@@ -29,13 +29,13 @@ description: Download CodeReady Containers for OKD.
           <h2>No Pull Secret Required!</h2>
           <p></p>
           <div class="row instructions"><large>
-            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/macos-amd64/" target="_blank">CodeReady Containers for OKD4 - Mac OS image</a>
+            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/release/macos-amd64/" target="_blank">CodeReady Containers for OKD4 - Mac OS image</a>
           </large></div>
           <div class="row instructions"><large>
-            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/linux-amd64/" target="_blank">CodeReady Containers for OKD4 - Linux image</a>
+            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/release/linux-amd64/" target="_blank">CodeReady Containers for OKD4 - Linux image</a>
           </large></div>
           <div class="row instructions"><large>
-            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/windows-amd64/" target="_blank">CodeReady Containers for OKD4 - Windows image</a>
+            <a href="https://dl.fedoraproject.org/pub/alt/okd-crc/release/windows-amd64/" target="_blank">CodeReady Containers for OKD4 - Windows image</a>
           </large></div>
           <div class="row instructions"><large>
             <a href="https://code-ready.github.io/crc/" target="_blank">Getting Started Guide</a>


### PR DESCRIPTION
The Fedora server that we are using to host OKD crc images has had some file permission changes that we need to fix.  In the mean time, I have moved the CRC binaries to another folder.