### PR TITLE
Removing the legacy mailing lists

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -268,9 +268,6 @@ title: OKD - The Community Distribution of Kubernetes that powers Red Hat OpenSh
           <h2>Talk to Us</h2>
           <ul>
             <li>
-              Follow the <a href="https://lists.openshift.redhat.com/openshiftmm/listinfo">public user or development mailing lists</a>
-            </li>
-            <li>
               Chat with us on the <a href="https://kubernetes.slack.com/messages/openshift-dev/">#openshift-dev channel on Slack</a>
             </li>
             <li>


### PR DESCRIPTION
These mailing lists were primarily used for okd 3.x.  There has been no
new threads since May and only 1 on the dev list this year and maybe 3
on the user list.

I intend to send a final email to these lists once this merges and is
live on the site letting people know that stackoverflow is the
appropriate place for community 3.11 questions and to join the working
group or slack channel.